### PR TITLE
Fix (android): Cover the screen in cover mode

### DIFF
--- a/templates/android/layout/launch_screen.cover.xml
+++ b/templates/android/layout/launch_screen.cover.xml
@@ -5,8 +5,8 @@
     android:layout_height="match_parent">
 
     <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:contentDescription="Splashscreen"
         android:scaleType="centerCrop"
         android:background="@color/splashprimary"


### PR DESCRIPTION
When using an image as a splash screen that does not match the screen dimensions in cover mode on Android, the image is fitted to the screen instead of properly covering the entire screen.
Changing the layout of the image to match its parent instead of matching the content size fixes this issue.