### PR TITLE
fix: Repair Android styles.xml Code indentation causes repeated additions styles code

### DIFF
--- a/src/services/file.processing.ts
+++ b/src/services/file.processing.ts
@@ -19,8 +19,8 @@ export const applyPatch = (
   path: string,
   { patch, pattern }: { patch: string; pattern: string | RegExp }
 ) => {
-  if (!readFile(path).includes(patch)) {
-    writeFileSync(path, readFileSync(path, 'utf8').replace(pattern, match => `${match}${patch}`));
+  if (!readFile(path).replace(/[\ +]|[\s\t\r\n]/g, "").includes(patch.replace(/[\ +]|[\s\t\r\n]/g, ""))) {
+    writeFileSync(path, readFileSync(path, 'utf8').replace(pattern, (match: any) => `${match}${patch}`));
   }
 };
 


### PR DESCRIPTION
If the user code is formatted and the indentation is different, the style code will be added multiple times.

![截屏2021-07-01 下午7 25 13](https://user-images.githubusercontent.com/39079814/124116920-17930400-daa2-11eb-9f34-f84c417e1feb.png)

After formatting the code styles.xml file
```
<resources>

<style name="SplashScreenTheme" parent="SplashScreen_SplashTheme">
    <item name="colorPrimaryDark">@color/splashprimary</item>
</style>

<!-- Base application theme. -->
<style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
    <!-- Customize your theme here. -->
    <item name="android:textColor">#000000</item>
    <item name="android:windowTranslucentStatus">true</item>
</style>

</resources>

```

You can reproduce it by using react-native-make again.
Enjoy your work and look forward to your reply.
